### PR TITLE
Updated lib/map.js to support wms layers.

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -286,7 +286,7 @@ define(["map/clientlayer", "map/labelslayer",
       var layers = config.mapLayers.map( function (d) {
         return {
           "name": d.name,
-          "layer": "url" in d ? L.tileLayer(d.url, d.config) : L.tileLayer.provider(d.name)
+          "layer": "url" in d ? "layers" in d.config ? L.tileLayer.wms(d.url, d.config) : L.tileLayer(d.url, d.config) : L.tileLayer.provider(d.name)
         }
       })
 


### PR DESCRIPTION
Added support for WMS Layers. WMS Layers can easily be identified by existence of the ``layers`` attribute  (required) within the options object (see [tileLayer.WMS](http://leafletjs.com/reference.html#tilelayer-wms) in leaflet apidoc).