### PR TITLE
Set a maximum zoom level for goto/updateView

### DIFF
--- a/lib/map.js
+++ b/lib/map.js
@@ -360,7 +360,13 @@ define(["map/clientlayer", "map/labelslayer",
       }
 
       function setView(bounds) {
-        map.fitBounds(bounds, {paddingTopLeft: [sidebar(), 0]})
+        var maxZoom = null
+        var curZoom = map.getZoom()
+
+        if ("maxGotoZoom" in config)
+          maxZoom = curZoom === undefined ? config.maxGotoZoom : Math.max(config.maxGotoZoom, map.getZoom())
+
+        map.fitBounds(bounds, {paddingTopLeft: [sidebar(), 0], maxZoom: maxZoom})
       }
 
       function resetZoom() {


### PR DESCRIPTION
This pull request implements a way to define a (optional) key ``maxGotoZoom`` to config.json. This value will be the maximum zoom level performed when clicking on a node or (mesh-)link etc..

The origin problem was that when clicking on a node always the maximum layer zoom level was selected because the boundingBox of a point will have no surface and therefore fitBounds will go to infinity.