### PR TITLE
Add support for Gluon domain_code

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,7 +180,7 @@ In this array name definitions for site statistics and node info can be saved. T
 - `site` the site code
 - `name` the defined written name for this site code
 
-If neither `siteNames` nor `showSites` are set, site statistics and node info won't be displayed
+If `siteNames` is not set, site-related statistics and node info won't be displayed.
 
 Example for `siteNames`:
 
@@ -189,4 +189,21 @@ Example for `siteNames`:
       { "site": "ffeh", "name": "Entenhausen" ),
       { "site": "ffgt", "name": "Gothamcity" },
       { "site": "ffal", "name": "Atlantis" }
+    ]
+
+## domainNames (array, optional)
+
+This array contains definitions for [Gluon domains](https://gluon.readthedocs.io/en/v2018.1.x/features/multidomain.html).
+This requires one object for each domain code. This object must contain:
+
+- `domain` the domain code
+- `name` the defined written name for this domain code
+
+If `domainNames` is not set, domain-related statistics and node info won't be displayed.
+
+Example for `domainNames`:
+
+    "domainNames": [
+      { "domain": "ffal-ost", "name": "Atlantis-Ost" },
+      { "domain": "ffal-west", "name": "Atlantis-West" }
     ]

--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -58,12 +58,27 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
 
   function showSite(d, config) {
     var site = dictGet(d.nodeinfo, ["system", "site_code"])
-    var rt = site
-    if (config.siteNames)
+    var rt = null
+    if (config.siteNames) {
+      rt = site
       config.siteNames.forEach( function (t) {
         if(site === t.site)
           rt = t.name
       })
+    }
+    return rt
+  }
+
+  function showDomain(d, config) {
+    var domain = dictGet(d.nodeinfo, ["system", "domain_code"])
+    var rt = null
+    if (config.domainNames) {
+      rt = domain
+      config.domainNames.forEach( function (t) {
+        if(domain === t.domain)
+          rt = t.name
+      })
+    }
     return rt
   }
 
@@ -462,6 +477,7 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
     attributeEntry(attributes, "Node ID", dictGet(d.nodeinfo, ["node_id"]))
     attributeEntry(attributes, "Firmware", showFirmware(d))
     attributeEntry(attributes, "Site", showSite(d, config))
+    attributeEntry(attributes, "Domain", showDomain(d, config))
     attributeEntry(attributes, "Uptime", showUptime(d))
     attributeEntry(attributes, "Teil des Netzes", showFirstseen(d))
     attributeEntry(attributes, "Kanal 2.4 GHz", showWifiChannel(dictGet(d.nodeinfo, ["wireless", "chan2"])))

--- a/lib/proportions.js
+++ b/lib/proportions.js
@@ -32,6 +32,9 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
     var siteTable = document.createElement("table")
     siteTable.classList.add("proportion")
 
+    var domainTable = document.createElement("table")
+    domainTable.classList.add("proportion")
+
     function showStatGlobal(o) {
       return showStat(o)
     }
@@ -188,6 +191,16 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
         return rt
       })
 
+      var domainDict = count(nodes, ["nodeinfo", "system", "domain_code"], function (d) {
+        var rt = d
+        if (config.domainNames)
+          config.domainNames.forEach( function (t) {
+            if(d === t.domain)
+              rt = t.name
+          })
+        return rt
+      })
+
       fillTable("Status", statusTable, statusDict.sort(function (a, b) { return b[1] - a[1] }))
       fillTable("Firmware", fwTable, fwDict.sort(function (a, b) { return vercomp(b[0], a[0]) }))
       fillTable("Hardware", hwTable, hwDict.sort(function (a, b) { return b[1] - a[1] }))
@@ -197,6 +210,7 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
       fillTable("Gateway", gwNodesTable, gwNodesDict.sort(function (a, b) { return b[1] - a[1] }))
       fillTable("Gateway", gwClientsTable, gwClientsDict.sort(function (a, b) { return b[1] - a[1] }))
       fillTable("Site", siteTable, siteDict.sort(function (a, b) { return b[1] - a[1] }))
+      fillTable("Domain", domainTable, domainDict.sort(function (a, b) { return b[1] - a[1] }))
     }
 
 
@@ -210,7 +224,10 @@ define(["chroma-js", "virtual-dom", "numeral-intl", "filters/genericnode", "verc
       self.renderSingle(el, "Hardwaremodelle", hwTable)
       self.renderSingle(el, "Auf der Karte sichtbar", geoTable)
       self.renderSingle(el, "Autoupdater", autoTable)
-      self.renderSingle(el, "Site", siteTable)
+      if (config.siteNames)
+        self.renderSingle(el, "Site", siteTable)
+      if (config.domainNames)
+        self.renderSingle(el, "Domain", domainTable)
 
       if (config.globalInfos)
         config.globalInfos.forEach(function (globalInfo) {


### PR DESCRIPTION
- Adds support for `domain_code` values from the Gluon multidomain feature
- Makes site/domain info visible depending on presence of `siteNames`/`domainNames`, as per README