### PR TITLE
fix airtime display

### DIFF
--- a/lib/infobox/node.js
+++ b/lib/infobox/node.js
@@ -289,10 +289,11 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
     }
   }
 
-  function showAirtime(band, val) {
-    if (!val)
+  function showAirtime(band, valFree) {
+    if (!valFree)
       return undefined
 
+    var val = 1 - valFree
     return function (el) {
       el.appendChild(showBar("airtime" + band.toString(), val))
     }
@@ -466,8 +467,8 @@ define(["moment", "numeral", "tablesort", "tablesort.numeric"],
     attributeEntry(attributes, "Teil des Netzes", showFirstseen(d))
     attributeEntry(attributes, "Kanal 2.4 GHz", showWifiChannel(dictGet(d.nodeinfo, ["wireless", "chan2"])))
     attributeEntry(attributes, "Kanal 5 GHz", showWifiChannel(dictGet(d.nodeinfo, ["wireless", "chan5"])))
-    attributeEntry(attributes, "Airtime 2.4 GHz", showAirtime(2, dictGet(d.statistics, ["wireless", "airtime2"])))
-    attributeEntry(attributes, "Airtime 5 GHz", showAirtime(5, dictGet(d.statistics, ["wireless", "airtime5"])))
+    attributeEntry(attributes, "Airtime 2.4 GHz", showAirtime(2, dictGet(d.statistics, ["wireless", "airtime2", "free"])))
+    attributeEntry(attributes, "Airtime 5 GHz", showAirtime(5, dictGet(d.statistics, ["wireless", "airtime5", "free"])))
     attributeEntry(attributes, "Systemlast", showLoad(d))
     attributeEntry(attributes, "Arbeitsspeicher", showRAM(d))
     attributeEntry(attributes, "IP Adressen", showIPs(d))


### PR DESCRIPTION
Currently, airtime just shows "NaN" for us. This patch fixes that.

Unlike https://github.com/hopglass/hopglass/pull/101, this also works correctly when a node doesn't have airtime information for a particular band.